### PR TITLE
⚡️ socket.ioのイベント登録処理修正, イベント[RES_START]追加

### DIFF
--- a/backend/utils/eventSend.ts
+++ b/backend/utils/eventSend.ts
@@ -6,7 +6,7 @@ const access = new dataAccessModel();
 export const broadcast = (
   roomId: string,
   eventName: string,
-  parameter: string
+  parameter: string = ""
 ): void => {
   const room = access.findRoom(roomId);
 

--- a/frontend/src/hooks/useSocketEvents.ts
+++ b/frontend/src/hooks/useSocketEvents.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { socket } from "../utils/socket";
 import { GameData } from "../interfaces/interface";
@@ -11,27 +11,39 @@ export const useSocketEvents = () => {
 
   const navigate = useNavigate();
 
-  socket.on("RES_CREATEROOM", (data) => {
-    setRoomId(data);
-    navigate("/standby");
-  });
+  useEffect(() => {
+    socket.on("RES_CREATEROOM", (data) => {
+      setRoomId(data);
+      navigate("/standby");
+    });
 
-  socket.on("NOTIFY_GAMEDATA", (data) => {
-    setGameData(JSON.parse(data));
-  });
+    socket.on("NOTIFY_GAMEDATA", (data) => {
+      setGameData(JSON.parse(data));
+    });
 
-  socket.on("RES_JOIN", () => {
-    navigate("/standby");
-  });
+    socket.on("RES_JOIN", () => {
+      navigate("/standby");
+    });
 
-  socket.on("NOTIFY_THEME", (data) => {
-    setTheme(data);
-    navigate("/play");
-  });
+    socket.on("NOTIFY_THEME", (data) => {
+      setTheme(data);
+    });
 
-  socket.on("NOTIFY_NUMBER", (data) => {
-    setNumber(Number(data));
-  });
+    socket.on("NOTIFY_NUMBER", (data) => {
+      setNumber(Number(data));
+    });
+
+    socket.on("RES_START", (data) => {
+      const errorMsg = data;
+
+      // エラーメッセージがない場合、ゲーム画面へ
+      if (errorMsg == "") {
+        navigate("/play");
+      } else {
+        console.log(errorMsg);
+      }
+    });
+  }, []);
 
   return { gameData, roomId, number, theme };
 };


### PR DESCRIPTION
・frontendのカスタムフック(useSocketEvents.ts)内で実行されているイベント登録をすべてuseEffect内で実行する修正をしました。
⇒再レンダリングのたびにイベントが再登録され、処理が複数回実行されるバグが発生していたため。

・backendから送信するイベントに[RES_START](ゲーム開始イベント)を追加しました。
⇒このイベントをfrontendで受信したとき、ゲーム画面へ遷移するように修正しました。
イベント[RES_START]の説明：
　・ホストからのイベント[REQ_START]に対する応答
　・イベント[REQ_START]をbackendで受信したときに、参加人数が3人以上いるかを判定し、いない場合、エラーメッセージを付与して、イベント[RES_START]をホストのみに送信するようにします。
　・参加人数が3人以上いる場合は、参加者全員にイベント[RES_START]の送信を行います。