### PR TITLE
✨ 🐛 解答を送信, 表示する機能の追加とルームIDの状態管理に関する修正

### DIFF
--- a/backend/utils/eventRcv.ts
+++ b/backend/utils/eventRcv.ts
@@ -129,6 +129,29 @@ const eventRcv = (socket: Socket) => {
     }
   });
   //#endregion
+
+  //#region イベント[UPDATE_GAMEDATA]受信
+  socket.on("UPDATE_GAMEDATA", (data) => {
+    console.log(socket.id);
+    console.log("受信しました。");
+
+    // 受信パラメータ解析
+    const parameter = JSON.parse(data);
+    // ルームID取得
+    const roomId = parameter.roomId;
+    // 解答取得
+    const answer = parameter.answer;
+
+    // 解答の設定
+    access.setAnswer(roomId, socket.id, answer);
+
+    // ゲームデータ取得
+    const gameData = access.getAllGameData(roomId);
+
+    // イベント[NOTIFY_GAMEDATA]送信
+    broadcast(roomId, "NOTIFY_GAMEDATA", JSON.stringify(gameData));
+  });
+  //#endregion
 };
 
 export default eventRcv;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ const App = () => {
     socket.connect();
   }, []);
 
-  const { gameData, roomId, theme, number } = useSocketEvents();
+  const { gameData, roomId, setRoomId, theme, number } = useSocketEvents();
 
   return (
     <div className="flex flex-col h-screen">
@@ -24,7 +24,14 @@ const App = () => {
       <Routes>
         <Route
           path="/"
-          element={<Home isHost={isHost} setIsHost={setIsHost} />}
+          element={
+            <Home
+              isHost={isHost}
+              setIsHost={setIsHost}
+              roomId={roomId}
+              setRoomId={setRoomId}
+            />
+          }
         />
         <Route
           path="/standby"

--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -1,5 +1,7 @@
+import { ChangeEvent, useState } from "react";
 import { GameData } from "../interfaces/interface";
 import DisplayAnswersSection from "./DisplayAnswersSection";
+import { socket } from "../utils/socket";
 
 interface GameProps {
   gameData: GameData[];
@@ -9,14 +11,12 @@ interface GameProps {
 }
 
 const Game = ({ gameData, roomId, theme, number }: GameProps) => {
-  console.log(roomId);
-
   return (
     <>
       <div className="flex flex-col flex-grow items-center justify-center container mx-auto px-4">
         <DisplayThemeCard theme={theme} />
         <DisplayNumberCard number={number} />
-        <AnswerForm />
+        <AnswerForm roomId={roomId} />
         <DisplayAnswersSection gameData={gameData} />
       </div>
     </>
@@ -34,7 +34,7 @@ const DisplayThemeCard = ({ theme }: { theme: string }) => {
   );
 };
 
-const DisplayNumberCard = ({number}: {number: number}) => {
+const DisplayNumberCard = ({ number }: { number: number }) => {
   return (
     <div className="card bg-base-100 flex items-center w-full max-w-3xl rounded-2xl border border-slate-100 shadow-md mt-2">
       <div className="card-body">
@@ -47,15 +47,36 @@ const DisplayNumberCard = ({number}: {number: number}) => {
   );
 };
 
-const AnswerForm = () => {
+const AnswerForm = ({ roomId }: { roomId: string }) => {
+  const [answer, setAnswer] = useState("");
+  const onChangeAnswer = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setAnswer(value);
+  };
+
+  const onClickSendAnswer = () => {
+    const data = {
+      roomId,
+      answer,
+    };
+
+    socket.emit("UPDATE_GAMEDATA", JSON.stringify(data));
+  };
+
   return (
     <div className="flex flex-col lg:flex-row max-w-3xl w-full mt-4">
       <input
         type="text"
         className="input input-bordered w-full"
         placeholder="回答のテキストを入力"
+        onChange={onChangeAnswer}
       />
-      <button className="btn btn-primary mt-2 lg:mt-0 lg:ml-4">Answer!</button>
+      <button
+        className="btn btn-primary mt-2 lg:mt-0 lg:ml-4"
+        onClick={onClickSendAnswer}
+      >
+        Answer!
+      </button>
     </div>
   );
 };

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -6,12 +6,14 @@ import Footer from "./Footer";
 const Home = ({
   isHost,
   setIsHost,
+  roomId,
+  setRoomId,
 }: {
   isHost: boolean;
   setIsHost: Dispatch<SetStateAction<boolean>>;
+  roomId: string;
+  setRoomId: Dispatch<SetStateAction<string>>;
 }) => {
-  const [roomId, setRoomId] = useState("");
-
   return (
     <>
       <div className="flex flex-col flex-grow items-center justify-center">

--- a/frontend/src/hooks/useSocketEvents.ts
+++ b/frontend/src/hooks/useSocketEvents.ts
@@ -52,5 +52,5 @@ export const useSocketEvents = () => {
     });
   }, []);
 
-  return { gameData, roomId, number, theme };
+  return { gameData, roomId, setRoomId, number, theme };
 };


### PR DESCRIPTION
ゲーム画面の、解答を送信する機能と、それを表示する機能を追加しました。
また、ホスト以外のルームIDをHomeコンポーネントだけで管理していたため、ゲーム画面からルームIDを送信できなかったため、HomeコンポーネントのルームIDのuseStateを削除し、カスタムフックで管理しているものをpropsで渡して利用するように修正しました。