### PR TITLE
⚡️ headタグの内容をルーティングされたページに応じて動的に変更

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-router-dom": "^6.23.1",
         "socket.io-client": "^4.7.5"
       },
@@ -4945,6 +4946,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -6388,6 +6397,24 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -6998,6 +7025,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-router-dom": "^6.23.1",
     "socket.io-client": "^4.7.5"
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import "./css/style.css";
+
 import { useState, useEffect } from "react";
 import { useSocketEvents } from "./hooks/useSocketEvents";
 import { Routes, Route } from "react-router-dom";
 import { socket } from "./utils/socket";
+
 import Header from "./components/Header";
 import ErrorAlert from "./components/ErrorAlert";
 import Home from "./components/Home";
@@ -31,50 +33,50 @@ const App = () => {
   } = useSocketEvents();
 
   return (
-    <div className="flex flex-col h-screen static">
-      <Header />
-      <ErrorAlert errorMsg={errorMsg} setErrorMsg={setErrorMsg} />
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <Home
-              isHost={isHost}
-              setIsHost={setIsHost}
-              roomId={roomId}
-              setRoomId={setRoomId}
-            />
-          }
-        />
-        <Route
-          path="/standby"
-          element={
-            <Standby
-              isHost={isHost}
-              gameData={gameData}
-              roomId={roomId}
-              setErrorMsg={setErrorMsg}
-            />
-          }
-        />
-        <Route
-          path="/play"
-          element={
-            <Game
-              isHost={isHost}
-              gameData={gameData}
-              setGameData={setGameData}
-              roomId={roomId}
-              theme={theme}
-              number={number}
-              resultFlg={resultFlg}
-              result={result}
-            />
-          }
-        />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </div>
+      <div className="flex flex-col h-screen static">
+        <Header />
+        <ErrorAlert errorMsg={errorMsg} setErrorMsg={setErrorMsg} />
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Home
+                isHost={isHost}
+                setIsHost={setIsHost}
+                roomId={roomId}
+                setRoomId={setRoomId}
+              />
+            }
+          />
+          <Route
+            path="/standby"
+            element={
+              <Standby
+                isHost={isHost}
+                gameData={gameData}
+                roomId={roomId}
+                setErrorMsg={setErrorMsg}
+              />
+            }
+          />
+          <Route
+            path="/play"
+            element={
+              <Game
+                isHost={isHost}
+                gameData={gameData}
+                setGameData={setGameData}
+                roomId={roomId}
+                theme={theme}
+                number={number}
+                resultFlg={resultFlg}
+                result={result}
+              />
+            }
+          />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </div>
   );
 };
 

--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -1,9 +1,11 @@
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import { GameData } from "../interfaces/interface";
-import DisplayAnswersSection from "./DisplayAnswersSection";
 import { socket } from "../utils/socket";
 import SocketEvent from "../class/socketEvents";
+
+import HeadBlock from "./HeadBlock";
+import DisplayAnswersSection from "./DisplayAnswersSection";
 
 interface GameProps {
   isHost: boolean;
@@ -28,6 +30,7 @@ const Game = ({
 }: GameProps) => {
   return (
     <>
+      <HeadBlock title="ito | Playing Game!" />
       <div className="flex flex-col flex-grow items-center justify-center container mx-auto px-4">
         <DisplayThemeCard theme={theme} />
         <DisplayNumberCard number={number} />

--- a/frontend/src/components/HeadBlock.tsx
+++ b/frontend/src/components/HeadBlock.tsx
@@ -1,0 +1,39 @@
+import { Helmet } from "react-helmet-async";
+
+const HeadBlock = ({ title }: { title: string }) => {
+  return (
+    <Helmet>
+      <title>{title ?? "ito(イト) | 価値観共有ゲーム"}</title>
+      <meta charSet="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta
+        name="description"
+        content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
+      />
+      <meta name="format-detection" content="telephone=no" />
+      <link rel="icon" href="favicon.ico" />
+      <meta property="og:site_name" content="ito(イト)" />
+      <meta property="og:url" content="https://www.ito-game.com/" />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content="ito(イト) | 価値観共有ゲーム" />
+      <meta
+        property="og:description"
+        content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
+      />
+      <meta property="og:image" content="https://www.ito-game.com/ogp.webp" />
+      <meta property="og:locale" content="ja_JP" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@yamap_web" />
+      <meta
+        name="twitter:description"
+        content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
+      />
+      <meta
+        name="twitter:image:src"
+        content="https://www.ito-game.com/ogp.webp"
+      />
+    </Helmet>
+  );
+};
+
+export default HeadBlock;

--- a/frontend/src/components/HeadBlock.tsx
+++ b/frontend/src/components/HeadBlock.tsx
@@ -3,7 +3,10 @@ import { Helmet } from "react-helmet-async";
 const HeadBlock = ({ title }: { title: string }) => {
   return (
     <Helmet>
+      {/* title */}
       <title>{title ?? "ito(イト) | 価値観共有ゲーム"}</title>
+
+      {/* meta */}
       <meta charSet="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta
@@ -11,7 +14,11 @@ const HeadBlock = ({ title }: { title: string }) => {
         content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
       />
       <meta name="format-detection" content="telephone=no" />
+
+      {/* favicon */}
       <link rel="icon" href="favicon.ico" />
+
+      {/* ogp */}
       <meta property="og:site_name" content="ito(イト)" />
       <meta property="og:url" content="https://www.ito-game.com/" />
       <meta property="og:type" content="website" />

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,8 +1,10 @@
 import type { Dispatch, SetStateAction, ChangeEvent } from "react";
 import { useState } from "react";
 import { socket } from "../utils/socket";
-import Footer from "./Footer";
 import SocketEvent from "../class/socketEvents";
+
+import HeadBlock from "./HeadBlock";
+import Footer from "./Footer";
 
 interface HomeProps {
   isHost: boolean;
@@ -14,6 +16,7 @@ interface HomeProps {
 const Home = ({ isHost, setIsHost, roomId, setRoomId }: HomeProps) => {
   return (
     <>
+      <HeadBlock title="ito(イト) | 価値観共有ゲーム" />
       <div className="flex flex-col flex-grow items-center justify-center">
         <h1 className="text-9xl font-bold tracking-wide">ito</h1>
         <p className="py-3 text-sm">

--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,11 +1,16 @@
 import { Link } from "react-router-dom";
+
+import HeadBlock from "./HeadBlock";
 import Footer from "./Footer";
 
 const NotFound = () => {
   return (
     <>
+      <HeadBlock title="ito | 404 NOT FOUND" />
       <div className="flex flex-col flex-grow items-center justify-center">
-        <h1 className="text-4xl lg:text-6xl font-bold tracking-wide">404 NOT FOUND</h1>
+        <h1 className="text-4xl lg:text-6xl font-bold tracking-wide">
+          404 NOT FOUND
+        </h1>
         <p className="py-3 text-sm">お探しのページが見つかりませんでした。</p>
         <Link to="/">
           <button className="btn mt-4">

--- a/frontend/src/components/Standby.tsx
+++ b/frontend/src/components/Standby.tsx
@@ -4,6 +4,8 @@ import { GameData } from "../interfaces/interface";
 import { socket } from "../utils/socket";
 import SocketEvent from "../class/socketEvents";
 
+import HeadBlock from "./HeadBlock";
+
 interface StandbyProps {
   isHost: boolean;
   gameData: GameData[];
@@ -13,23 +15,26 @@ interface StandbyProps {
 
 const Standby = ({ isHost, gameData, roomId, setErrorMsg }: StandbyProps) => {
   return (
-    <div className="flex flex-col justify-center flex-grow container mx-auto mt-10 lg:mt-0 px-4">
-      <DisplayIdCard isHost={isHost} roomId={roomId} />
-      <div className="flex flex-col lg:flex-row items-center justify-center mb-10">
-        <div className="max-w-sm w-full">
-          <PlayersStat gameData={gameData} />
-          <PlayersList gameData={gameData} />
-        </div>
-        <div className="max-w-2xl w-full mt-4 lg:mt-0 lg:ml-6">
-          <DisplayRuleAccordion />
-          <InputThemeForm
-            isHost={isHost}
-            roomId={roomId}
-            setErrorMsg={setErrorMsg}
-          />
+    <>
+      <HeadBlock title="ito | On Standby Now..." />
+      <div className="flex flex-col justify-center flex-grow container mx-auto mt-10 lg:mt-0 px-4">
+        <DisplayIdCard isHost={isHost} roomId={roomId} />
+        <div className="flex flex-col lg:flex-row items-center justify-center mb-10">
+          <div className="max-w-sm w-full">
+            <PlayersStat gameData={gameData} />
+            <PlayersList gameData={gameData} />
+          </div>
+          <div className="max-w-2xl w-full mt-4 lg:mt-0 lg:ml-6">
+            <DisplayRuleAccordion />
+            <InputThemeForm
+              isHost={isHost}
+              roomId={roomId}
+              setErrorMsg={setErrorMsg}
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,38 +1,6 @@
 <!DOCTYPE html>
 <html data-theme="pastel" lang="ja">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ito(イト) - 価値観共有ゲーム</title>
-    <meta
-      name="description"
-      content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
-    />
-    <meta name="format-detection" content="telephone=no" />
-    <!-- favicon -->
-    <link rel="icon" href="favicon.ico" />
-    <!-- ogp -->
-    <meta property="og:site_name" content="ito(イト)" />
-    <meta property="og:url" content="https://www.ito-game.com/" />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="ito(イト) - 価値観共有ゲーム" />
-    <meta
-      property="og:description"
-      content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
-    />
-    <meta property="og:image" content="https://www.ito-game.com/ogp.webp" />
-    <meta property="og:locale" content="ja_JP" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@yamap_web" />
-    <meta
-      name="twitter:description"
-      content="大人気パーティーゲームがブラウザ版アプリとして遊べるようになりました。ルールは1つ、数字を口に出したらアウト！テーマに沿ってその数字の大きさを表現し合い、配られた1~100のカードの並び順を協力して当ててクリアを目指します。"
-    />
-    <meta
-      name="twitter:image:src"
-      content="https://www.ito-game.com/ogp.webp"
-    />
-  </head>
+  <head> </head>
   <body>
     <div id="root"></div>
   </body>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,7 @@
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 
 const rootElm = document.getElementById("root");
@@ -7,8 +9,12 @@ const rootElm = document.getElementById("root");
 if (rootElm) {
   const root = createRoot(rootElm);
   root.render(
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <StrictMode>
+      <HelmetProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </HelmetProvider>
+    </StrictMode>
   );
 }


### PR DESCRIPTION
## headタグの内容をルーティングされたページに応じて動的に変更
### 概要
- headタグも動的に管理するようにし、homeなら「ito(イト) | 価値観共有ゲーム」、standbyなら「ito | On Standby Now...」など変更
### 詳細な変更内容
- `react-helmet-async`の導入
- `HeadBlock.tsx`の追加

### 参考
https://yumegori.com/react_helmet_async_method
https://www.npmjs.com/package/react-helmet-async