### PR TITLE
⚡️ イベント受信処理のイベント名の指定方法の修正

### DIFF
--- a/frontend/src/class/socketEvents.ts
+++ b/frontend/src/class/socketEvents.ts
@@ -3,10 +3,12 @@ import { GameData } from "../interfaces/interface";
 // イベントの抽象クラス
 abstract class EventClass {
   abstract parseEventParameter(parameter: string): EventClass;
+  public abstract EventName: string;
 }
 
 // RES_CREATEROOM
 class RES_CREATEROOM implements EventClass {
+  public EventName: string = "RES_CREATEROOM";
   public roomId: string = "";
 
   constructor(roomId: string = "") {
@@ -21,6 +23,7 @@ class RES_CREATEROOM implements EventClass {
 
 // NOTIFY_GAMEDATA
 class NOTIFY_GAMEDATA implements EventClass {
+  public EventName: string = "NOTIFY_GAMEDATA";
   public gameData: GameData[] = [];
 
   constructor(gameData: GameData[] = []) {
@@ -35,6 +38,7 @@ class NOTIFY_GAMEDATA implements EventClass {
 
 // RES_JOIN
 class RES_JOIN implements EventClass {
+  public EventName: string = "RES_JOIN";
   public errorMsg: string = "";
 
   constructor(errorMsg: string = "") {
@@ -49,6 +53,7 @@ class RES_JOIN implements EventClass {
 
 // NOTIFY_THEME
 class NOTIFY_THEME implements EventClass {
+  public EventName: string = "NOTIFY_THEME";
   public theme: string = "";
 
   constructor(theme: string = "") {
@@ -63,6 +68,7 @@ class NOTIFY_THEME implements EventClass {
 
 // NOTIFY_NUMBER
 class NOTIFY_NUMBER implements EventClass {
+  public EventName: string = "NOTIFY_NUMBER";
   public number: number = 0;
 
   constructor(number: number = 0) {
@@ -77,6 +83,7 @@ class NOTIFY_NUMBER implements EventClass {
 
 // RES_START
 class RES_START implements EventClass {
+  public EventName: string = "RES_START";
   public errorMsg: string = "";
 
   constructor(errorMsg: string = "") {
@@ -91,6 +98,7 @@ class RES_START implements EventClass {
 
 // RES_RESULT
 class RES_RESULT implements EventClass {
+  public EventName: string = "RES_RESULT";
   public result: boolean = false;
 
   constructor(result: boolean = false) {

--- a/frontend/src/hooks/useSocketEvents.ts
+++ b/frontend/src/hooks/useSocketEvents.ts
@@ -16,20 +16,16 @@ export const useSocketEvents = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    socket.on("RES_CREATEROOM", (data) => {
-      console.log("RES_CREATEROOMを受信", data);
-      
+    socket.on(SocketEvents.RES_CREATEROOM.EventName, (data) => {
       setRoomId(data);
       navigate("/standby");
     });
 
-    socket.on(SocketEvents.NOTIFY_GAMEDATA.constructor.name, (data) => {
-      console.log("NOTIFY_GAMEDATAを受信", data);
-      
+    socket.on(SocketEvents.NOTIFY_GAMEDATA.EventName, (data) => {
       setGameData(JSON.parse(data));
     });
 
-    socket.on(SocketEvents.RES_JOIN.constructor.name, (data) => {
+    socket.on(SocketEvents.RES_JOIN.EventName, (data) => {
       const RES_JOIN = SocketEvents.RES_JOIN.parseEventParameter(data);
 
       // エラーメッセージがない場合、待機画面へ
@@ -41,15 +37,15 @@ export const useSocketEvents = () => {
       }
     });
 
-    socket.on(SocketEvents.NOTIFY_THEME.constructor.name, (data) => {
+    socket.on(SocketEvents.NOTIFY_THEME.EventName, (data) => {
       setTheme(data);
     });
 
-    socket.on(SocketEvents.NOTIFY_NUMBER.constructor.name, (data) => {
+    socket.on(SocketEvents.NOTIFY_NUMBER.EventName, (data) => {
       setNumber(data);
     });
 
-    socket.on(SocketEvents.RES_START.constructor.name, (data) => {
+    socket.on(SocketEvents.RES_START.EventName, (data) => {
       const RES_START = SocketEvents.RES_START.parseEventParameter(data);
 
       // エラーメッセージがない場合、ゲーム画面へ
@@ -61,7 +57,7 @@ export const useSocketEvents = () => {
       }
     });
 
-    socket.on(SocketEvents.RES_RESULT.constructor.name, (data) => {
+    socket.on(SocketEvents.RES_RESULT.EventName, (data) => {
       const RES_RESULT = SocketEvents.RES_RESULT.parseEventParameter(data);
       setResultFlg(true);
       setResult(RES_RESULT.result);


### PR DESCRIPTION
イベント受信処理のイベント名の指定方法を、クラス名(型)から取得していたが、クラスにイベント名を直接持たせ、それを指定する方法へ変更。
Reactでは、ビルド時に型情報が削除されてしまうらしい。確かに、JavaScriptへトランスパイルされることを考えると、もともと型を持たないJavaScriptでは削除されて当然なのだが、
なぜ、開発モードでは問題なかったのか...