### PR TITLE
🐛 Clientsデータの削除方法修正

### DIFF
--- a/backend/models/clientDataAccessModel.ts
+++ b/backend/models/clientDataAccessModel.ts
@@ -8,11 +8,19 @@ class ClientDataAccessModel {
   }
 
   /** Clientの削除 */
-  public deleteClient(socketId: string) {
-    for (let i = 0; i < clients.length; i++) {
-      if (clients[i].socketId == socketId) {
-        clients.splice(i, 1);
-      }
+  public deleteClient(roomId: string) {
+    // roomIdと一致しないデータの抽出
+    const newClientData = clients.filter((client) => client.roomId != roomId);
+
+    // Clientデータの初期化
+    const length = clients.length;
+    for (let i = 0; i < length; i++) {
+      clients.pop();
+    }
+
+    // Clientデータの再構築
+    for (let i = 0; i < newClientData.length; i++) {
+      clients.push(newClientData[i]);
     }
   }
 

--- a/backend/utils/eventRcv.ts
+++ b/backend/utils/eventRcv.ts
@@ -26,7 +26,7 @@ const eventRcv = (socket: Socket) => {
     }
 
     // Clientデータから削除
-    clientAccess.deleteClient(socket.id);
+    clientAccess.deleteClient(roomId);
   });
   //#endregion
 
@@ -273,7 +273,7 @@ const eventRcv = (socket: Socket) => {
     access.deleteRoom(REQ_CLOSEROOM.roomId);
 
     // Clientデータから削除
-    clientAccess.deleteClient(socket.id);
+    clientAccess.deleteClient(REQ_CLOSEROOM.roomId);
   });
   //#endregion
 };


### PR DESCRIPTION
clientsデータの削除方法が、socket.idと一致するデータの削除になっていたため、roomIdと一致するデータの削除に修正。