### PR TITLE
✨ ユーザーネーム未入力時のエラー結果返却（イベント[REQ_CREATEROOM]）

### DIFF
--- a/backend/class/SocketEvent.ts
+++ b/backend/class/SocketEvent.ts
@@ -22,8 +22,7 @@ class REQ_CREATEROOM implements EventClass {
 
   //#region パラメータ解析メソッド
   parseEventParameter(parameter: string): REQ_CREATEROOM {
-    // const { userName } = JSON.parse(parameter);
-    const userName = parameter;
+    const { userName } = JSON.parse(parameter);
 
     return new REQ_CREATEROOM(userName);
   }
@@ -178,17 +177,23 @@ class REQ_CLOSEROOM implements EventClass {
 }
 
 class REQ_NEXTGAME implements EventClass {
+  //#region イベントパラメータ
   public roomId: string = "";
+  //#endregion
 
+  //#region コンストラクタ
   constructor(roomId: string = "") {
     this.roomId = roomId;
   }
+  //#endregion
 
+  //#region パラメータ解析メソッド
   parseEventParameter(parameter: string): REQ_NEXTGAME {
     const { roomId } = JSON.parse(parameter);
 
     return new REQ_NEXTGAME(roomId);
   }
+  //#endregion
 }
 //#endregion
 

--- a/backend/utils/eventRcv.ts
+++ b/backend/utils/eventRcv.ts
@@ -41,6 +41,21 @@ const eventRcv = (socket: Socket) => {
     // 受信パラメータ取得(userName)
     const REQ_CREATEROOM = SocketEvent.REQ_CREATEROOM.parseEventParameter(data);
 
+    // ユーザー名チェック（未入力の場合、エラー）
+    if (REQ_CREATEROOM.userName === "") {
+      const errParameter = {
+        roomId: "",
+        errorMsg: "ユーザーネームが未入力です。",
+      };
+      sendEvent(
+        socket.id,
+        SocketEvent.RES_CREATEROOM,
+        JSON.stringify(errParameter)
+      );
+
+      return;
+    }
+
     // ルームID取得
     const roomId = createRoomId();
 
@@ -57,7 +72,11 @@ const eventRcv = (socket: Socket) => {
     sendEvent(socket.id, SocketEvent.NOTIFY_GAMEDATA, JSON.stringify(gameData));
 
     // イベント[RES_CREATEROOM]送信
-    sendEvent(socket.id, SocketEvent.RES_CREATEROOM, roomId);
+    const parameter = {
+      roomId,
+      errorMsg: "",
+    };
+    sendEvent(socket.id, SocketEvent.RES_CREATEROOM, JSON.stringify(parameter));
   });
   //#endregion
 

--- a/frontend/src/class/socketEvents.ts
+++ b/frontend/src/class/socketEvents.ts
@@ -10,14 +10,17 @@ abstract class EventClass {
 class RES_CREATEROOM implements EventClass {
   public EventName: string = "RES_CREATEROOM";
   public roomId: string = "";
+  public errorMsg: string = "";
 
-  constructor(roomId: string = "") {
+  constructor(roomId: string = "", errorMsg: string = "") {
     this.roomId = roomId;
+    this.errorMsg = errorMsg;
   }
 
   parseEventParameter(parameter: string): RES_CREATEROOM {
-    const roomId: string = parameter;
-    return new RES_CREATEROOM(roomId);
+    const { roomId, errorMsg } = JSON.parse(parameter);
+
+    return new RES_CREATEROOM(roomId, errorMsg);
   }
 }
 

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -69,7 +69,8 @@ const EntryRoomForm = ({
   const handleEntryBtnClick = (isHost: boolean) => {
     if (isHost) {
       setIsHost(true);
-      socket.emit(SocketEvent.REQ_CREATEROOM, userName);
+      const parameter = { userName };
+      socket.emit(SocketEvent.REQ_CREATEROOM, JSON.stringify(parameter));
     } else {
       setIsHost(false);
       const parameter = { userName, roomId };

--- a/frontend/src/hooks/useSocketEvents.ts
+++ b/frontend/src/hooks/useSocketEvents.ts
@@ -16,8 +16,16 @@ export const useSocketEvents = () => {
 
   useEffect(() => {
     socket.on(SocketEvents.RES_CREATEROOM.EventName, (data) => {
-      setRoomId(data);
-      navigate("/standby");
+      const RES_CREATEROOM =
+        SocketEvents.RES_CREATEROOM.parseEventParameter(data);
+
+      if (RES_CREATEROOM.errorMsg == "") {
+        setErrorMsg("");
+        setRoomId(RES_CREATEROOM.roomId);
+        navigate("/standby");
+      } else {
+        setErrorMsg(RES_CREATEROOM.errorMsg);
+      }
     });
 
     socket.on(SocketEvents.NOTIFY_GAMEDATA.EventName, (data) => {
@@ -67,7 +75,6 @@ export const useSocketEvents = () => {
     });
 
     socket.on(SocketEvents.RES_NEXTGAME.EventName, () => {
-      // 状態管理のリセット（どこまで）
       navigate("/standby");
     });
   }, []);


### PR DESCRIPTION
イベント[RES_CREATEROOM]で受け取るパラメータが、roomIdのみだったために、オブジェクトとしてやり取りしていなかったが、本対応でエラーメッセージを追加したので、オブジェクトでのやり取りに変更。